### PR TITLE
Removing relative imports so that it can be tested with pytest from getpelican/plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ python:
     - "3.7"
 cache: pip
 install:
-    - pip install Markdown -e git+https://github.com/getpelican/pelican.git#egg=pelican
-script: nosetests
+    - pip install Markdown pytest -e git+https://github.com/getpelican/pelican.git#egg=pelican
+script: pytest

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
 # This file is only necessary so that it can be used as a git submodule in https://github.com/getpelican/pelican-plugins
-from .linkclass import *
+from linkclass import *

--- a/linkclass/linkclass.py
+++ b/linkclass/linkclass.py
@@ -19,7 +19,7 @@
 import os
 import sys
 from pelican import signals
-from . mdx_linkclass import LinkClassExtension, LC_CONFIG, LC_HELP
+from mdx_linkclass import LinkClassExtension, LC_CONFIG, LC_HELP
 
 def addLinkClass (gen):
 

--- a/linkclass/test_linkclass.py
+++ b/linkclass/test_linkclass.py
@@ -26,7 +26,7 @@ from tempfile import mkdtemp
 from shutil import rmtree
 from six import StringIO
 
-from . import linkclass
+import linkclass
 from pelican import Pelican
 from pelican.settings import read_settings
 


### PR DESCRIPTION
Without this fix I get this failure:
```
_____________ ERROR collecting pelican-linkclass/test_linkclass.py _____________
ImportError while importing test module '/home/travis/build/Lucas-C/pelican-plugins/pelican-linkclass/test_linkclass.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
pelican-linkclass/test_linkclass.py:29: in <module>
    from . import linkclass
E   ImportError: attempted relative import with no known parent package
```