### PR TITLE
Fix import of `mdx_linkclass` in `linkclass.py`

### DIFF
--- a/linkclass/linkclass.py
+++ b/linkclass/linkclass.py
@@ -19,7 +19,7 @@
 import os
 import sys
 from pelican import signals
-from mdx_linkclass import LinkClassExtension, LC_CONFIG, LC_HELP
+from .mdx_linkclass import LinkClassExtension, LC_CONFIG, LC_HELP
 
 def addLinkClass (gen):
 


### PR DESCRIPTION
Again, this is a "fix" in the sense that it makes it possible to run tests from `getpelican/pelican-plugins`.

Without this fix:
```
$ pytest pelican-linkclass/
========================================================= test session starts =========================================================
platform cygwin -- Python 3.7.4, pytest-5.1.3, py-1.8.0, pluggy-0.13.0
rootdir: /opt/pelican-plugins
collected 0 items / 1 errors

=============================================================== ERRORS ================================================================
___________________________________ ERROR collecting pelican-linkclass/linkclass/test_linkclass.py ____________________________________
ImportError while importing test module '/opt/pelican-plugins/pelican-linkclass/linkclass/test_linkclass.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
pelican-linkclass/linkclass/__init__.py:1: in <module>
    from .linkclass import *
pelican-linkclass/linkclass/linkclass.py:22: in <module>
    from mdx_linkclass import LinkClassExtension, LC_CONFIG, LC_HELP
E   ModuleNotFoundError: No module named 'mdx_linkclass'
```

With this fix:
```
$ pytest pelican-linkclass/
========================================================= test session starts =========================================================
platform cygwin -- Python 3.7.4, pytest-5.1.3, py-1.8.0, pluggy-0.13.0
rootdir: /opt/pelican-plugins
collected 6 items

pelican-linkclass/linkclass/test_linkclass.py ......                                                                            [100%]
```

I should have tested this when you asked for review, sorry !