### PR TITLE
Ensure plugin is included in sdist build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ Funding = "https://donate.getpelican.com/"
 [project.optional-dependencies]
 markdown = ["markdown>=3.4"]
 
+[tool.pdm]
+
 [tool.pdm.dev-dependencies]
 lint = [
     "black>=23.10.1",
@@ -49,6 +51,16 @@ test = [
     "pytest-cov>=4.0",
     "pytest-sugar>=0.9.7",
 ]
+
+[tool.pdm.build]
+source-includes = [
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "external-link.png",
+    "linkclass-example.png",
+]
+includes = ["pelican/"]
+excludes = ["tasks.py"]
 
 [tool.autopub]
 project-name = "Link Class"


### PR DESCRIPTION
Prior to the additions in this PR, the `pelican/plugins/` directory was not included in the `sdist` tarball.

I *think* this should fix the problem reported in #38.