### PR TITLE
Add target=_blank and title attributes to external links (configurable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,18 @@ Configuration
 In order to avoid clashes with already-defined classes in the user CSS style sheets, it is possible to specify the name of the classes that will be used. They can be specified in the Pelican setting file with the `LINKCLASS` variable, which must be defined as a list of tuples, like this:
 
 ```python
-'LINKCLASS' = (('EXTERNAL_CLASS', 'name-of-the-class-for-external-links'),
-               ('INTERNAL_CLASS', 'name-of-the-class-for-internal-links'))
+LINKCLASS = [
+    ('EXTERNAL_CLASS', 'name-of-the-class-for-external-links'),
+    ('INTERNAL_CLASS', 'name-of-the-class-for-internal-links'),
+    ('TARGETBLANK', True/False)
+    ('TOOLTIP',"Set to a string, this will be the title to show when hovering over a link. Use {0} to add the link itself."),
++]
 ```
 
-The default values for `EXTERNAL_CLASS` and `INTERNAL_CLASS` are, respectively, `'external'` and `'internal'`.
+If opening external links in a new tab is not desired, set `'TARGETBLANK'` to `False`.
 
+The default values for `'EXTERNAL_CLASS'` and `'INTERNAL_CLASS'` are, respectively, `'external'` and `'internal'`.
+`'TOOLTIP'` is empty by default.
 
 Styling Hyperlinks
 ------------------

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ LINKCLASS = [
     ('INTERNAL_CLASS', 'name-of-the-class-for-internal-links'),
     ('TARGETBLANK', True/False)
     ('TOOLTIP',"Set to a string, this will be the title to show when hovering over a link. Use {0} to add the link itself."),
-+]
+]
 ```
 
 If opening external links in a new tab is not desired, set `'TARGETBLANK'` to `False`.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ LINKCLASS = [
 If opening external links in a new tab is desired, set `'TARGETBLANK'` to `True`.
 
 The default values for `'EXTERNAL_CLASS'` and `'INTERNAL_CLASS'` are, respectively, `'external'` and `'internal'`.  
-'TARGETBLANK'` is `False`, and `'TOOLTIP'` is empty by default.
+`'TARGETBLANK'` is `False`, and `'TOOLTIP'` is empty by default.
 
 Styling Hyperlinks
 ------------------

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ LINKCLASS = [
 ]
 ```
 
-If opening external links in a new tab is not desired, set `'TARGETBLANK'` to `False`.
+If opening external links in a new tab is desired, set `'TARGETBLANK'` to `True`.
 
-The default values for `'EXTERNAL_CLASS'` and `'INTERNAL_CLASS'` are, respectively, `'external'` and `'internal'`.
-`'TOOLTIP'` is empty by default.
+The default values for `'EXTERNAL_CLASS'` and `'INTERNAL_CLASS'` are, respectively, `'external'` and `'internal'`.  
+'TARGETBLANK'` is `False`, and `'TOOLTIP'` is empty by default.
 
 Styling Hyperlinks
 ------------------

--- a/pelican/plugins/linkclass/mdx_linkclass.py
+++ b/pelican/plugins/linkclass/mdx_linkclass.py
@@ -44,7 +44,8 @@ def add_class(elm, config):
             elm.set("target", "_blank")
         if config["TOOLTIP"] != "" and m:
             str = config["TOOLTIP"].format(l)
-            elm.set("title", str)    except AttributeError:
+            elm.set("title", str)    
+    except AttributeError:
         pass
     return elm
 

--- a/pelican/plugins/linkclass/mdx_linkclass.py
+++ b/pelican/plugins/linkclass/mdx_linkclass.py
@@ -25,19 +25,26 @@ from markdown.inlinepatterns import (
     ReferenceInlineProcessor,
 )
 
-LC_CONFIG = {"INTERNAL_CLASS": "internal", "EXTERNAL_CLASS": "external"}
+LC_CONFIG = {"INTERNAL_CLASS": "internal", "EXTERNAL_CLASS": "external", "TARGETBLANK": False, "TOOLTIP": ""}
 LC_HELP = {
     "INTERNAL_CLASS": "Name of the CSS class for internal links",
     "EXTERNAL_CLASS": "Name of the CSS class for external links",
+    "TARGETBLANK": "Open external links in a new tab/window if True",
+    "TOOLTIP": "Set to a string, this will be the title to show when hovering over a link. Use {0} to add the link itself.",
 }
 
 
 def add_class(elm, config):
     """Utlity function for adding the appropriate class attribute."""
     try:
-        m = re.match("^https?://", elm.get("href"))
+        l = elm.get("href")
+        m = re.match("^https?://", l)
         elm.set("class", (m and config["EXTERNAL_CLASS"]) or config["INTERNAL_CLASS"])
-    except AttributeError:
+        if config["TARGETBLANK"] == True and m:
+            elm.set("target", "_blank")
+        if config["TOOLTIP"] != "" and m:
+            str = config["TOOLTIP"].format(l)
+            elm.set("title", str)    except AttributeError:
         pass
     return elm
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pelican-linkclass"
-version = "2.1.5"
+version = "2.1.7"
 description = "Pelican plugin to set anchor tag's class attribute to differentiate between internal and external links"
 authors = [{name = "Rafael Laboissière", email = "rafael@laboissiere.net"}]
 license = {text = "AGPL-3.0"}


### PR DESCRIPTION
Thanks for your plugin!

I added these changes. Without explicitely enabling them functionality remains the same as before.

I hope you like them & will integrate them.
